### PR TITLE
Remove vendored version of curve25519-dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,23 +21,23 @@ std = ["alloc", "core2/std", "hex/std", "uint-zigzag/std"]
 
 [dependencies]
 core2 = { version = "0.4", default-features = false }
-curve25519-dalek = { version = "4.0.0", optional = true, package = "curve25519-dalek-ml" }
+curve25519-dalek = { version = "3", optional = true }
 elliptic-curve = { version = "0.12", features = ["ecdh"], optional = true }
 k256 = { version = "0.11", features = ["arithmetic", "bits", "serde"], optional = true }
 hex = { version = "0.4", default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
+rand_chacha_02 = { version = "0.2", package = "rand_chacha", default-features = false }
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["serde_derive"] }
 serde-big-array = "0.4"
 serde_cbor = { version = "0.11", optional = true }
-sha2 = { version = "0.10", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.4", optional = true }
 uint-zigzag = { version = "0.2" }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 bls12_381_plus = "0.5.3"
-curve25519-dalek = { version = "4.0.0", package = "curve25519-dalek-ml" }
 ed25519-dalek = "1.0"
 k256 = { version = "0.11.6", features = ["arithmetic", "bits"] }
 p256 = { version = "0.11.1", features = ["arithmetic", "bits"] }
@@ -47,5 +47,4 @@ rand_xorshift = "0.3"
 serde_json = "1.0"
 serde_cbor = "0.11"
 serde_bare = "0.5"
-sha2v9 = { version = "0.9", package = "sha2" }
 x25519-dalek = "1.1"

--- a/src/curve25519.rs
+++ b/src/curve25519.rs
@@ -26,8 +26,8 @@ use elliptic_curve::{
     ff::{Field, PrimeField},
     group::{Group, GroupEncoding},
 };
-use rand_chacha::ChaChaRng;
-use rand_core::{RngCore, SeedableRng};
+use rand_chacha_02::{ChaChaRng, rand_core::SeedableRng}; // for curve25519_dalek compatability
+use rand_core::RngCore;
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
@@ -956,7 +956,7 @@ impl<'de> Deserialize<'de> for WrappedScalar {
 
 #[test]
 fn ristretto_to_edwards() {
-    let mut osrng = rand::rngs::OsRng::default();
+    let mut osrng = rand_7::rngs::OsRng::default();
     let sk = Scalar::random(&mut osrng);
     let pk = RISTRETTO_BASEPOINT_POINT * sk;
     let ek = WrappedEdwards::from(WrappedRistretto(pk));

--- a/src/tests/no_std/bls12_381_tests.rs
+++ b/src/tests/no_std/bls12_381_tests.rs
@@ -49,8 +49,8 @@ fn group_combine() {
         bytes.copy_from_slice(s.value());
         let sk = Scalar::from_bytes(&bytes).unwrap();
 
-        let h1 = G1Projective::hash::<ExpandMsgXmd<sha2v9::Sha256>>(msg, dst);
-        let h2 = G2Projective::hash::<ExpandMsgXmd<sha2v9::Sha256>>(msg, dst);
+        let h1 = G1Projective::hash::<ExpandMsgXmd<sha2::Sha256>>(msg, dst);
+        let h2 = G2Projective::hash::<ExpandMsgXmd<sha2::Sha256>>(msg, dst);
 
         let s1 = h1 * sk;
         let s2 = h2 * sk;
@@ -74,9 +74,9 @@ fn group_combine() {
     let sig1 = res1.unwrap().to_affine();
     let sig2 = G2Prepared::from(res2.unwrap().to_affine());
 
-    let h1 = G1Projective::hash::<ExpandMsgXmd<sha2v9::Sha256>>(msg, dst).to_affine();
+    let h1 = G1Projective::hash::<ExpandMsgXmd<sha2::Sha256>>(msg, dst).to_affine();
     let h2 =
-        G2Prepared::from(G2Projective::hash::<ExpandMsgXmd<sha2v9::Sha256>>(msg, dst).to_affine());
+        G2Prepared::from(G2Projective::hash::<ExpandMsgXmd<sha2::Sha256>>(msg, dst).to_affine());
 
     let pk1 = (G1Projective::GENERATOR * secret).to_affine();
     let pk2 = G2Prepared::from((G2Projective::GENERATOR * secret).to_affine());

--- a/src/tests/no_std/curve25519_tests.rs
+++ b/src/tests/no_std/curve25519_tests.rs
@@ -32,8 +32,9 @@ fn valid_tests() {
 
 #[test]
 fn key_tests() {
-    let mut osrng = rand::rngs::OsRng::default();
-    let sc = Scalar::random(&mut osrng);
+    let mut osrng = OsRng::default();
+    let mut osrng7 = rand_7::rngs::OsRng::default();
+    let sc = Scalar::random(&mut osrng7);
     let sk1 = StaticSecret::from(sc.to_bytes());
     let ske1 = SecretKey::from_bytes(&sc.to_bytes()).unwrap();
     let res = Shamir::<2, 3>::split_secret::<WrappedScalar, OsRng, 33>(sc.into(), &mut osrng);
@@ -52,7 +53,8 @@ fn key_tests() {
 #[test]
 fn feldman_verifier_serde_test() {
     let mut osrng = OsRng::default();
-    let sk = Scalar::random(&mut osrng);
+    let mut osrng7 = rand_7::rngs::OsRng::default();
+    let sk = Scalar::random(&mut osrng7);
     let res = Feldman::<2, 3>::split_secret::<WrappedScalar, WrappedRistretto, OsRng, 33>(
         sk.into(),
         None,
@@ -93,7 +95,8 @@ fn feldman_verifier_serde_test() {
 #[test]
 fn pedersen_verifier_serde_test() {
     let mut osrng = OsRng::default();
-    let sk = Scalar::random(&mut osrng);
+    let mut osrng7 = rand_7::rngs::OsRng::default();
+    let sk = Scalar::random(&mut osrng7);
     let res = Pedersen::<2, 3>::split_secret::<WrappedScalar, WrappedEdwards, OsRng, 33>(
         sk.into(),
         None,

--- a/src/tests/standard/bls12_381_tests.rs
+++ b/src/tests/standard/bls12_381_tests.rs
@@ -50,8 +50,8 @@ fn group_combine() {
         bytes.copy_from_slice(s.value());
         let sk = Scalar::from_bytes(&bytes).unwrap();
 
-        let h1 = G1Projective::hash::<ExpandMsgXmd<sha2v9::Sha256>>(msg, dst);
-        let h2 = G2Projective::hash::<ExpandMsgXmd<sha2v9::Sha256>>(msg, dst);
+        let h1 = G1Projective::hash::<ExpandMsgXmd<sha2::Sha256>>(msg, dst);
+        let h2 = G2Projective::hash::<ExpandMsgXmd<sha2::Sha256>>(msg, dst);
 
         let s1 = h1 * sk;
         let s2 = h2 * sk;
@@ -75,9 +75,9 @@ fn group_combine() {
     let sig1 = res1.unwrap().to_affine();
     let sig2 = G2Prepared::from(res2.unwrap().to_affine());
 
-    let h1 = G1Projective::hash::<ExpandMsgXmd<sha2v9::Sha256>>(msg, dst).to_affine();
+    let h1 = G1Projective::hash::<ExpandMsgXmd<sha2::Sha256>>(msg, dst).to_affine();
     let h2 =
-        G2Prepared::from(G2Projective::hash::<ExpandMsgXmd<sha2v9::Sha256>>(msg, dst).to_affine());
+        G2Prepared::from(G2Projective::hash::<ExpandMsgXmd<sha2::Sha256>>(msg, dst).to_affine());
 
     let pk1 = (G1Projective::GENERATOR * secret).to_affine();
     let pk2 = G2Prepared::from((G2Projective::GENERATOR * secret).to_affine());


### PR DESCRIPTION
Thanks for creating this library, it is very useful! However, I noticed that a vendored version of `curve25519-dalek` was used as a dependency for other dependency reasons. It is usually not a good idea to use vendored versions of cryptographic libraries if avoidable.  This PR does the minimum amount of work to replace the vendored version of `curve25519-dalek`. This makes the dependency tree more transparent with less maintenance.

Process:
1. Change `curve25519-dalek` dependency to upstream
2. It uses an older digest trait incompatible with `sha2` 0.10, so downgrade `sha2` dependency to 0.9 (no 0.10 features were used anyways)
3. Refactor `sha2v9` dev dependency out because conflicting dependency build errors
4. Add in `rand_chacha_02` dependency because `curve25519-dalek` uses an older version of `rand_chacha`
5. Refactor `OsRng` tests as necessary

Now we are forwards compatible for `curve25519-dalek` with no maintenance needed and no vendoring. 
