### PR TITLE
fix default and no-default-features compiler warning

### DIFF
--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -354,7 +354,7 @@ impl ShareIdentifier for usize {
 
     #[cfg(any(feature = "alloc", feature = "std"))]
     fn to_vec(&self) -> Vec<u8> {
-        match core::mem::size_of::<usize>() {
+        match size_of::<usize>() {
             4 => {
                 let r = *self as u32;
                 r.to_vec()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,9 @@ mod identifier;
 #[cfg(feature = "curve25519")]
 pub use curve25519_dalek;
 pub use elliptic_curve;
-use elliptic_curve::{group::GroupEncoding, Group, PrimeField};
+#[cfg(feature = "std")]
+use elliptic_curve::Group;
+use elliptic_curve::{group::GroupEncoding, PrimeField};
 pub use subtle;
 
 /// Create a no-std verifiable secret sharing scheme with size $num using fixed arrays


### PR DESCRIPTION
Hi, I found that build with some warnings.

```shell
cargo c --no-default-features 
warning: unused import: `Group`
   --> src/lib.rs:213:44
    |
213 | use elliptic_curve::{group::GroupEncoding, Group, PrimeField};
    |                                            ^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: `vsss-rs` (lib) generated 1 warning
```

```shell
 cargo c
error: unnecessary qualification
   --> src/identifier.rs:357:15
    |
357 |         match core::mem::size_of::<usize>() {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:147:5
    |
147 |     unused_qualifications,
    |     ^^^^^^^^^^^^^^^^^^^^^
help: remove the unnecessary path segments
    |
357 -         match core::mem::size_of::<usize>() {
357 +         match size_of::<usize>() {
    |

error: could not compile `vsss-rs` (lib) due to 1 previous error

```