### PR TITLE
implement missing traits to allow IdentifierResidue being used as a Share

### DIFF
--- a/src/element/residue.rs
+++ b/src/element/residue.rs
@@ -1,7 +1,7 @@
 use core::{
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
-    ops::{Deref, DerefMut},
+    ops::{Deref, DerefMut, Mul},
 };
 use elliptic_curve::bigint::modular::constant_mod::{Residue, ResidueParams};
 use elliptic_curve::bigint::{ArrayEncoding, Uint};
@@ -121,6 +121,16 @@ where
     }
 }
 
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> From<&IdentifierResidue<MOD, LIMBS>>
+    for IdentifierResidue<MOD, LIMBS>
+where
+    Uint<LIMBS>: ArrayEncoding,
+{
+    fn from(value: &IdentifierResidue<MOD, LIMBS>) -> Self {
+        Self(value.0)
+    }
+}
+
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> From<IdentifierResidue<MOD, LIMBS>>
     for Residue<MOD, LIMBS>
 where
@@ -128,6 +138,18 @@ where
 {
     fn from(value: IdentifierResidue<MOD, LIMBS>) -> Self {
         value.0
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Mul<&IdentifierResidue<MOD, LIMBS>>
+    for IdentifierResidue<MOD, LIMBS>
+where
+    Uint<LIMBS>: ArrayEncoding,
+{
+    type Output = IdentifierResidue<MOD, LIMBS>;
+
+    fn mul(self, rhs: &IdentifierResidue<MOD, LIMBS>) -> Self {
+        Self(Residue::<MOD, LIMBS>::mul(&self, &rhs))
     }
 }
 


### PR DESCRIPTION
currently, `Share` requires the associated `Value` type to implement `ShareElement + for<'a> From<&'a Self::Identifier> + for<'a> Mul<&'a Self::Identifier, Output = Self::Value>`, which is not implemented for `IdentifierResidue`, preventing the use of, for example, `(IdentifierResidue, IdentifierResidue)` as a `Share`.
this pr just adds the two necessary trait implementations to allow a `Share` consisting of two `IdentifierResidue`s.